### PR TITLE
Fix 'ScrollController not attached to any scroll views'

### DIFF
--- a/lib/any_widget_marquee.dart
+++ b/lib/any_widget_marquee.dart
@@ -41,17 +41,19 @@ class _AnyMargueeWidgetState extends State<AnyMargueeWidget> {
   @override
   void initState() {
     super.initState();
-    _scrollController = new ScrollController();
+    _scrollController = ScrollController();
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) async {
-      await Future.delayed(widget.delayedStart).then((value) => startTimer());
+      await Future.delayed(widget.delayedStart);
+      startTimer();
     });
   }
 
   void startTimer() {
     _anyMargueeTimer = Timer.periodic(Duration(microseconds: 16), (timer) {
-      final distance = _scrollController.offset ?? 0;
-      if (_scrollController.hasClients)
+      if (_scrollController.hasClients) {
+        final distance = _scrollController.offset ?? 0;
         _scrollController.jumpTo(distance + (1 / AnyMargueeSpeed.NORMAL_SPEED) * widget.speedRate);
+      }
     });
   }
 
@@ -94,8 +96,8 @@ class _AnyMargueeWidgetState extends State<AnyMargueeWidget> {
   @override
   void dispose() {
     _anyMargueeTimer.cancel();
-    _scrollController.dispose();
     super.dispose();
+    _scrollController.dispose();
   }
 }
 

--- a/lib/any_widget_marquee.dart
+++ b/lib/any_widget_marquee.dart
@@ -95,9 +95,9 @@ class _AnyMargueeWidgetState extends State<AnyMargueeWidget> {
 
   @override
   void dispose() {
-    _anyMargueeTimer.cancel();
+    _anyMargueeTimer?.cancel();
     super.dispose();
-    _scrollController.dispose();
+    _scrollController?.dispose();
   }
 }
 


### PR DESCRIPTION
Relocated 'final distance = _scrollController.offset ?? 0;' line in order to avoid the ''_positions.isNotEmpty': ScrollController not attached to any scroll views.' error that occasionally occurs.
It was relocated in the 'if (_scrollController.hasClients)' condition.